### PR TITLE
Improve logging

### DIFF
--- a/pip_manage/_logging.py
+++ b/pip_manage/_logging.py
@@ -13,7 +13,7 @@ else:  # pragma: <3.12 cover
     from typing_extensions import override
 
 
-class _StdOutFilter(logging.Filter):
+class _NonErrorFilter(logging.Filter):
     @override
     def filter(self, record: logging.LogRecord) -> bool:
         return record.levelno <= logging.INFO
@@ -21,13 +21,13 @@ class _StdOutFilter(logging.Filter):
 
 class _ColoredFormatter(logging.Formatter):
     COLORS: ClassVar[dict[str, str]] = {
-        "DEBUG": "\033[0;37m",
-        "INFO": "\033[0;32m",
-        "WARNING": "\033[0;33m",
-        "ERROR": "\033[0;31m",
-        "CRITICAL": "\033[1;31m",
+        "DEBUG": "\x1b[0;37m",
+        "INFO": "\x1b[0;32m",
+        "WARNING": "\x1b[0;33m",
+        "ERROR": "\x1b[0;31m",
+        "CRITICAL": "\x1b[1;31m",
     }
-    RESET: ClassVar[Literal["\033[0m"]] = "\033[0m"
+    RESET: ClassVar[Literal["\x1b[0m"]] = "\x1b[0m"
 
     @override
     def format(self, record: logging.LogRecord) -> str:
@@ -36,7 +36,7 @@ class _ColoredFormatter(logging.Formatter):
         return super().format(record)
 
 
-def setup_logging(*, verbose: bool) -> None:
+def setup_logging(logger_name: str, *, verbose: bool) -> None:
     level: Literal["DEBUG", "INFO"] = "DEBUG" if verbose else "INFO"
     logging.config.dictConfig(
         {
@@ -52,7 +52,7 @@ def setup_logging(*, verbose: bool) -> None:
             },
             "filters": {
                 "StdOutFilter": {
-                    "()": _StdOutFilter,
+                    "()": _NonErrorFilter,
                 },
             },
             "handlers": {
@@ -71,11 +71,11 @@ def setup_logging(*, verbose: bool) -> None:
                 },
             },
             "loggers": {
-                "root": {
-                    "level": level,
+                "": {
+                    "level": "DEBUG",
                     "handlers": ["stdout", "stderr"],
-                    "propagate": True,
                 },
+                logger_name: {"level": level, "propagate": True},
             },
         },
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ lint.ignore = [
   "B905",
   "TD002",
   "TD003",
+  "TRY400",
 ]
 lint.fixable = ["ALL"]
 lint.unfixable = []

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -11,9 +11,9 @@ import pytest
 
 from pip_manage._pip_interface import _OutdatedPackage
 
-if sys.version_info >= (3, 10):  # pragma: >=3.12 cover
+if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
     from typing import ParamSpec
-else:  # pragma: <3.12 cover
+else:  # pragma: <3.10 cover
     from typing_extensions import ParamSpec
 
 _P = ParamSpec("_P")

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -2,13 +2,19 @@ from __future__ import annotations
 
 import logging
 import logging.config
+import sys
 from functools import wraps
 from types import SimpleNamespace
-from typing import Callable, ParamSpec, TypeVar
+from typing import Callable, TypeVar
 
 import pytest
 
 from pip_manage._pip_interface import _OutdatedPackage
+
+if sys.version_info >= (3, 10):  # pragma: >=3.12 cover
+    from typing import ParamSpec
+else:  # pragma: <3.12 cover
+    from typing_extensions import ParamSpec
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
@@ -25,7 +31,7 @@ def retain_pytest_handlers(f: Callable[_P, _R]) -> Callable[_P, _R]:
         ]
         ret: _R = f(*args, **kwargs)
         for handler in pytest_handlers:
-            if handler not in logging.root.handlers:
+            if handler not in logging.root.handlers:  # pragma: no cover
                 logging.root.addHandler(handler)
         return ret
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -21,7 +21,7 @@ _R = TypeVar("_R")
 
 
 # https://github.com/pytest-dev/pytest/discussions/11618
-def retain_pytest_handlers(f: Callable[_P, _R]) -> Callable[_P, _R]:
+def _retain_pytest_handlers(f: Callable[_P, _R]) -> Callable[_P, _R]:
     @wraps(f)
     def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
         pytest_handlers: list[logging.Handler] = [
@@ -43,7 +43,7 @@ def _keep_pytest_handlers_during_dict_config(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(
         logging.config,
         "dictConfig",
-        retain_pytest_handlers(logging.config.dictConfig),
+        _retain_pytest_handlers(logging.config.dictConfig),
     )
 
 

--- a/tests/pip_purge_test.py
+++ b/tests/pip_purge_test.py
@@ -13,7 +13,10 @@ import pytest
 
 from pip_manage import pip_purge
 from pip_manage._pip_interface import PIP_CMD
-from tests.fixtures import dummy_dependencies  # pylint: disable=W0611
+from tests.fixtures import (  # pylint: disable=W0611
+    _keep_pytest_handlers_during_dict_config,
+    dummy_dependencies,
+)
 
 
 def _raise_package_not_found_error_when_package_c(package: str) -> None:
@@ -50,11 +53,6 @@ def test_constants(
     expected: str | frozenset[str] | tuple[str, ...],
 ) -> None:
     assert constant == expected
-
-
-def test_default_settings_pip_purge_logger() -> None:
-    assert pip_purge._logger.name == "pip-purge"
-    assert len(pip_purge._logger.handlers) == 2
 
 
 def test_parse_args_empty_args() -> None:
@@ -428,7 +426,7 @@ def test_main_verbose_flag_sets_logger_level_to_debug(
         "subprocess.call",
     ) as mock_subprocess_call:
         exit_code: int = pip_purge.main(["package_a", arg])
-    assert pip_purge._logger.level == logging.DEBUG
+    assert logging.getLogger("pip-purge").level == logging.DEBUG
     mock_subprocess_call.assert_called_once_with(
         [*PIP_CMD, "uninstall", "package_a", "package_b", "package_e"],
         stdout=sys.stdout,
@@ -453,7 +451,7 @@ def test_main_no_verbose_flag_sets_logger_level_to_info(
         "subprocess.call",
     ) as mock_subprocess_call:
         exit_code: int = pip_purge.main(["package_a"])
-    assert pip_purge._logger.level == logging.INFO
+    assert logging.getLogger("pip-purge").level == logging.INFO
     mock_subprocess_call.assert_called_once_with(
         [*PIP_CMD, "uninstall", "package_a", "package_b", "package_e"],
         stdout=sys.stdout,
@@ -473,7 +471,14 @@ def test_main_error_exit_when_no_packages_provided(
         "subprocess.call",
     ) as mock_subprocess_call:
         exit_code: int = pip_purge.main([])
-    assert caplog.record_tuples == [("pip-purge", 40, "No packages provided")]
+    assert caplog.record_tuples == [
+        (
+            "pip-purge",
+            40,
+            "\x1b[0;31mERROR: You must give at least one requirement to "
+            "uninstall\x1b[0m",
+        ),
+    ]
     mock_subprocess_call.assert_not_called()
     assert exit_code == 1
 
@@ -492,9 +497,14 @@ def test_main_warn_about_unrecognized_args_before_error_exit_when_no_packages_pr
     assert (
         "pip-purge",
         30,
-        "Unrecognized arguments: '-a', '-b'",
+        "\x1b[0;33mWARNING: Unrecognized arguments: '-a', '-b'\x1b[0m",
     ) in caplog.record_tuples
-    assert ("pip-purge", 40, "No packages provided") in caplog.record_tuples
+    assert (
+        "pip-purge",
+        40,
+        "\x1b[0;31mERROR: You must give at least one requirement to "
+        "uninstall\x1b[0m",
+    ) in caplog.record_tuples
     mock_subprocess_call.assert_not_called()
     assert exit_code == 1
 
@@ -519,7 +529,7 @@ def test_main_warn_about_unrecognized_args(
     assert (
         "pip-purge",
         30,
-        "Unrecognized arguments: '-a', '-b'",
+        "\x1b[0;33mWARNING: Unrecognized arguments: '-a', '-b'\x1b[0m",
     ) in caplog.record_tuples
     mock_subprocess_call.assert_called_once_with(
         [*PIP_CMD, "uninstall", "-y", "package_a", "package_b", "package_e"],
@@ -547,7 +557,11 @@ def test_main_warn_about_not_installed_packages(
     ):
         exit_code: int = pip_purge.main(["package_a", "package_x"])
     assert caplog.record_tuples == [
-        ("pip-purge", 30, "package_x is not installed"),
+        (
+            "pip-purge",
+            30,
+            "\x1b[0;33mWARNING: Skipping package_x as it is not installed\x1b[0m",
+        ),
         (
             "pip-purge",
             20,

--- a/tests/pip_review_test.py
+++ b/tests/pip_review_test.py
@@ -11,7 +11,11 @@ import pytest
 
 from pip_manage import pip_review
 from pip_manage._pip_interface import PIP_CMD, _OutdatedPackage
-from tests.fixtures import sample_packages, sample_subprocess_output
+from tests.fixtures import (  # pylint: disable=W0611
+    _keep_pytest_handlers_during_dict_config,
+    sample_packages,
+    sample_subprocess_output,
+)
 
 # pylint: disable=W0212, E1101, W0621, C0302, R0913, C0301
 
@@ -54,11 +58,6 @@ def test_constants(
     ),
 ) -> None:
     assert constant == expected
-
-
-def test_default_settings_pip_review_logger() -> None:
-    assert pip_review._logger.name == "pip-review"
-    assert len(pip_review._logger.handlers) == 2
 
 
 def test_parse_args_empty_args() -> None:
@@ -431,7 +430,7 @@ def test_main_verbose_flag_sets_logger_level_to_debug(
         "subprocess.call",
     ) as mock_subprocess_call:
         exit_code: int = pip_review.main([arg])
-    assert pip_review._logger.level == logging.DEBUG
+    assert logging.getLogger("pip-review").level == logging.DEBUG
     mock_subprocess_call.assert_not_called()
     assert exit_code == 0
 
@@ -452,7 +451,7 @@ def test_main_no_verbose_flag_sets_logger_level_to_info(
         "subprocess.call",
     ) as mock_subprocess_call:
         exit_code: int = pip_review.main([])
-    assert pip_review._logger.level == logging.INFO
+    assert logging.getLogger("pip-review").level == logging.INFO
     mock_subprocess_call.assert_not_called()
     assert exit_code == 0
 
@@ -460,14 +459,17 @@ def test_main_no_verbose_flag_sets_logger_level_to_info(
 @pytest.mark.parametrize(
     ("args", "err_msg"),
     [
-        (["--raw", "--auto"], "'--raw' and '--auto' cannot be used together"),
+        (
+            ["--raw", "--auto"],
+            "\x1b[0;31mERROR: '--raw' and '--auto' cannot be used together\x1b[0m",
+        ),
         (
             ["--raw", "--interactive"],
-            "'--raw' and '--interactive' cannot be used together",
+            "\x1b[0;31mERROR: '--raw' and '--interactive' cannot be used together\x1b[0m",
         ),
         (
             ["--auto", "--interactive"],
-            "'--auto' and '--interactive' cannot be used together",
+            "\x1b[0;31mERROR: '--auto' and '--interactive' cannot be used together\x1b[0m",
         ),
     ],
 )
@@ -502,7 +504,7 @@ def test_main_warn_about_unrecognized_args(
     assert (
         "pip-review",
         30,
-        "Unrecognized arguments: '-x'",
+        "\x1b[0;33mWARNING: Unrecognized arguments: '-x'\x1b[0m",
     ) in caplog.record_tuples
     expected_cmd: list[str] = [
         *PIP_CMD,
@@ -522,14 +524,17 @@ def test_main_warn_about_unrecognized_args(
 @pytest.mark.parametrize(
     ("args", "err_msg"),
     [
-        (["--raw", "--auto"], "'--raw' and '--auto' cannot be used together"),
+        (
+            ["--raw", "--auto"],
+            "\x1b[0;31mERROR: '--raw' and '--auto' cannot be used together\x1b[0m",
+        ),
         (
             ["--raw", "--interactive"],
-            "'--raw' and '--interactive' cannot be used together",
+            "\x1b[0;31mERROR: '--raw' and '--interactive' cannot be used together\x1b[0m",
         ),
         (
             ["--auto", "--interactive"],
-            "'--auto' and '--interactive' cannot be used together",
+            "\x1b[0;31mERROR: '--auto' and '--interactive' cannot be used together\x1b[0m",
         ),
     ],
 )
@@ -543,7 +548,7 @@ def test_main_mutually_warn_about_unrecognized_args_before_exclusive_args_error(
         (
             "pip-review",
             30,
-            "Unrecognized arguments: '-x'",
+            "\x1b[0;33mWARNING: Unrecognized arguments: '-x'\x1b[0m",
         ),
         ("pip-review", 40, err_msg),
     ]


### PR DESCRIPTION
- Improve the error message to be more consistent with `pip`
- Use `logging.config.dictConfig`
- Move logger instance inside `main`
- Rename `_StdOutFilter` to `_NonErrorFilter`
